### PR TITLE
DBP-1084-rollout-to-namespaces-do-not-delete-dbs

### DIFF
--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -63,13 +63,13 @@ jobs:
 
   branch_meta:
     if: ${{ github.event_name == 'push' && !startsWith(github.ref_name,'dependabot/') }}
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/get-branch-meta.yml@3
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/get-branch-meta.yml@6
 
   create_branch_identifier:
     if: ${{ github.event_name == 'push' && !startsWith(github.ref_name,'dependabot/') }}
     needs: 
       - branch_meta
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1179-convert-branch-to-image-tag-and-chart-version # todo change back to correct version
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6
     with:
       branch: ${{ needs.branch_meta.outputs.branch }}
 
@@ -93,7 +93,7 @@ jobs:
   # On Delete
   create_branch_identifier_for_deletion:
     if: ${{ github.event_name == 'delete' && github.event.ref_type == 'branch' }}
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1179-convert-branch-to-image-tag-and-chart-version # todo change back to correct version
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6
     with:
       branch: ${{ github.event.ref }}
 

--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -66,7 +66,7 @@ jobs:
     if: ${{ github.event_name == 'push' && !startsWith(github.ref_name,'dependabot/') }}
     needs: 
       - branch_meta
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6.0
     with:
       branch: ${{ needs.branch_meta.outputs.branch }}
 

--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -66,7 +66,7 @@ jobs:
     if: ${{ github.event_name == 'push' && !startsWith(github.ref_name,'dependabot/') }}
     needs: 
       - branch_meta
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6.0
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6
     with:
       branch: ${{ needs.branch_meta.outputs.branch }}
 

--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -66,7 +66,7 @@ jobs:
     if: ${{ github.event_name == 'push' && !startsWith(github.ref_name,'dependabot/') }}
     needs: 
       - branch_meta
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy-branch-to-namespace.yml@3
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1084-rollout-to-namespaces-do-not-delete-dbs
     with:
       branch: ${{ needs.branch_meta.outputs.branch }}
 
@@ -76,19 +76,21 @@ jobs:
       - branch_meta
       - create_branch_identifier
       - wait_for_helm_chart_to_get_published
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@5 
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@DBP-1084-rollout-to-namespaces-do-not-delete-dbs
     with:
       dbildungs_iam_server_branch: ${{ needs.branch_meta.outputs.ticket }}
       schulportal_client_branch: ${{ needs.branch_meta.outputs.ticket }}
       dbildungs_iam_keycloak_branch: ${{ needs.branch_meta.outputs.ticket }}
       dbildungs_iam_ldap_branch: ${{ needs.branch_meta.outputs.ticket }}
       namespace: ${{ needs.create_branch_identifier.outputs.namespace_from_branch }}
+      # database_deletion: ${{ github.ref_name == 'main' && 'true' || 'false' }}"
+      database_deletion: "true"
     secrets: inherit
 
   # On Delete
   create_branch_identifier_for_deletion:
     if: ${{ github.event_name == 'delete' && github.event.ref_type == 'branch' }}
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy-branch-to-namespace.yml@3
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1084-rollout-to-namespaces-do-not-delete-dbs
     with:
       branch: ${{ github.event.ref }}
 

--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -24,30 +24,33 @@ jobs:
     if: ${{ github.event_name == 'push' && !startsWith(github.ref_name,'dependabot/') }}
     runs-on: ubuntu-latest
     outputs: 
-      SELECT_HELM_VERION_GENERATION: ${{ steps.select_generation.outputs.SELECT_HELM_VERION_GENERATION }}
+      SELECT_HELM_VERSION_GENERATION: ${{ steps.select_generation.outputs.SELECT_HELM_VERSION_GENERATION }}
       SELECT_IMAGE_TAG_GENERATION: ${{ steps.select_generation.outputs.SELECT_IMAGE_TAG_GENERATION }}
     steps:
       - id: select_generation
         shell: bash
         run: |
           if ${{ github.ref_name == 'main' }}; then
-            echo "SELECT_HELM_VERION_GENERATION=timestamp" >> "$GITHUB_OUTPUT"
+            echo "SELECT_HELM_VERSION_GENERATION=timestamp" >> "$GITHUB_OUTPUT"
             echo "SELECT_IMAGE_TAG_GENERATION=commit_hash" >> "$GITHUB_OUTPUT"
           else
-            echo "SELECT_HELM_VERION_GENERATION=ticket_from_branch_timestamp" >> "$GITHUB_OUTPUT"
-            echo "SELECT_IMAGE_TAG_GENERATION=ticket_from_branch" >> "$GITHUB_OUTPUT"
+            echo "SELECT_HELM_VERSION_GENERATION=specified" >> "$GITHUB_OUTPUT"
+            echo "SELECT_IMAGE_TAG_GENERATION=specified" >> "$GITHUB_OUTPUT"
           fi
 
   release_helm:
     if: ${{ github.event_name == 'push' && !startsWith(github.ref_name,'dependabot/') }}
-    needs: 
+    needs:
+      - create_branch_identifier
       - select_helm_version_generation_and_image_tag_generation
     uses: dBildungsplattform/dbp-github-workflows/.github/workflows/chart-release.yaml@7
     secrets: inherit
     with:
       chart_name: dbildungs-iam-ldap
-      helm_chart_version_generation: ${{ needs. select_helm_version_generation_and_image_tag_generation.outputs.SELECT_HELM_VERION_GENERATION  }}
-      image_tag_generation: ${{ needs. select_helm_version_generation_and_image_tag_generation.outputs.SELECT_IMAGE_TAG_GENERATION  }}
+      helm_chart_version_generation: ${{ needs. select_helm_version_generation_and_image_tag_generation.outputs.SELECT_HELM_VERSION_GENERATION }}
+      helm_chart_version: ${{ github.ref_name == 'main' && '' || needs.create_branch_identifier.outputs.chart_version_from_branch }}
+      image_tag_generation: ${{ needs. select_helm_version_generation_and_image_tag_generation.outputs.SELECT_IMAGE_TAG_GENERATION }}
+      image_tag: ${{ github.ref_name == 'main' && '' || needs.create_branch_identifier.outputs.image_tag_from_branch }}
 
   wait_for_helm_chart_to_get_published:
     needs:
@@ -66,7 +69,7 @@ jobs:
     if: ${{ github.event_name == 'push' && !startsWith(github.ref_name,'dependabot/') }}
     needs: 
       - branch_meta
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1179-convert-branch-to-image-tag-and-chart-version # todo change back to correct version
     with:
       branch: ${{ needs.branch_meta.outputs.branch }}
 
@@ -90,7 +93,7 @@ jobs:
   # On Delete
   create_branch_identifier_for_deletion:
     if: ${{ github.event_name == 'delete' && github.event.ref_type == 'branch' }}
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1179-convert-branch-to-image-tag-and-chart-version # todo change back to correct version
     with:
       branch: ${{ github.event.ref }}
 

--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -83,8 +83,8 @@ jobs:
       dbildungs_iam_keycloak_branch: ${{ needs.branch_meta.outputs.ticket }}
       dbildungs_iam_ldap_branch: ${{ needs.branch_meta.outputs.ticket }}
       namespace: ${{ needs.create_branch_identifier.outputs.namespace_from_branch }}
-      # database_deletion: ${{ github.ref_name == 'main' && 'true' || 'false' }}"
-      database_deletion: "true" # to force database deletion this has be set to true
+      # database_recreation: ${{ github.ref_name == 'main' && 'true' || 'false' }}"
+      database_recreation: "true" # to force database recreation this has be set to true
     secrets: inherit
 
   # On Delete

--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -84,7 +84,7 @@ jobs:
       dbildungs_iam_ldap_branch: ${{ needs.branch_meta.outputs.ticket }}
       namespace: ${{ needs.create_branch_identifier.outputs.namespace_from_branch }}
       # database_deletion: ${{ github.ref_name == 'main' && 'true' || 'false' }}"
-      database_deletion: "true"
+      database_deletion: "true" # to force database deletion this has be set to true
     secrets: inherit
 
   # On Delete

--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -66,7 +66,7 @@ jobs:
     if: ${{ github.event_name == 'push' && !startsWith(github.ref_name,'dependabot/') }}
     needs: 
       - branch_meta
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1084-rollout-to-namespaces-do-not-delete-dbs
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6
     with:
       branch: ${{ needs.branch_meta.outputs.branch }}
 
@@ -76,21 +76,21 @@ jobs:
       - branch_meta
       - create_branch_identifier
       - wait_for_helm_chart_to_get_published
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@DBP-1084-rollout-to-namespaces-do-not-delete-dbs
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/deploy.yml@6
     with:
       dbildungs_iam_server_branch: ${{ needs.branch_meta.outputs.ticket }}
       schulportal_client_branch: ${{ needs.branch_meta.outputs.ticket }}
       dbildungs_iam_keycloak_branch: ${{ needs.branch_meta.outputs.ticket }}
       dbildungs_iam_ldap_branch: ${{ needs.branch_meta.outputs.ticket }}
       namespace: ${{ needs.create_branch_identifier.outputs.namespace_from_branch }}
-      # database_recreation: ${{ github.ref_name == 'main' && 'true' || 'false' }}"
-      database_recreation: "true" # to force database recreation this has be set to true
+      database_recreation: ${{ github.ref_name == 'main' && 'true' || 'false' }}"
+      # database_recreation: "true" # to force database recreation this has be set to true
     secrets: inherit
 
   # On Delete
   create_branch_identifier_for_deletion:
     if: ${{ github.event_name == 'delete' && github.event.ref_type == 'branch' }}
-    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@DBP-1084-rollout-to-namespaces-do-not-delete-dbs
+    uses: dBildungsplattform/spsh-app-deploy/.github/workflows/convert-branch-name.yml@6
     with:
       branch: ${{ github.event.ref }}
 

--- a/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
+++ b/.github/workflows/image-and-helm-publish-check-deploy-on-push-scheduled.yml
@@ -83,7 +83,7 @@ jobs:
       dbildungs_iam_keycloak_branch: ${{ needs.branch_meta.outputs.ticket }}
       dbildungs_iam_ldap_branch: ${{ needs.branch_meta.outputs.ticket }}
       namespace: ${{ needs.create_branch_identifier.outputs.namespace_from_branch }}
-      database_recreation: ${{ github.ref_name == 'main' && 'true' || 'false' }}"
+      database_recreation: ${{ github.ref_name == 'main' && 'true' || 'false' }}
       # database_recreation: "true" # to force database recreation this has be set to true
     secrets: inherit
 


### PR DESCRIPTION
# Description

- Switch to Version 6 of convert-branch-name and get-branch-meta (DBP-1179 -> https://github.com/dBildungsplattform/spsh-app-deploy/commit/5ff578fa4ed704a0069448c03fd9ca64153b02f1)
- **New Feature - New Naming Conventions:** 
  - branches with alpha-digit-digit blocks can now be deployed with corresponding image-tag, chart-version and k8s namespace, this allows _release-X-X_ branches
  - the generated kubernetes namespace identifier does not incorporate the complete branch name anymore. Multiple Namespaces with the same ticket number were not functioning anyway, since the ingress could not share a name. Restricting the Namesape enabled us to improve the pipeline complexity. 
- **New Feature - Optional Database Recreation:** 
  - it is now possible to set a boolean (actually it is a string) for database recreation in the deploy job of the dev pipeline to enable/disable database recreation
  - Per default databases are now only recreated if branch is main
  - If one wants to recreate databases on deployment, one can set the database_recreation to "true" or manually delete them

Successfully tested here: https://github.com/dBildungsplattform/dbildungs-iam-ldap/actions/runs/12388670680

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.